### PR TITLE
API-CLIENTE: Refatorando os testes de cadastros

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,14 @@
 		<version>2.6.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>net.atos</groupId>
-	<artifactId>api-cliente</artifactId>
+	<groupId>net.atos.api</groupId>
+	<artifactId>cliente</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>api-cliente</name>
-	<description>Demo project for Spring Boot</description>
+	<name>cliente</name>
+	<description>Acelera Atos - Desafio Java Gama Academy</description>
 	<properties>
 		<java.version>11</java.version>
+		<java-hamcrest.version>2.0.0.0</java-hamcrest.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -43,6 +44,22 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>java-hamcrest</artifactId>
+			<version>${java-hamcrest.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>2.23.0</version><!--$NO-MVN-MAN-VER$-->
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/net/atos/cliente/domain/Cliente.java
+++ b/src/main/java/net/atos/cliente/domain/Cliente.java
@@ -3,24 +3,42 @@ package net.atos.cliente.domain;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import javax.validation.constraints.NotNull;
+
 public class Cliente {
+	
+	@NotNull(message="Campo: cadastroData não pode ser nulo")
 	private LocalDate dataCadastro;
+	
+	@NotNull(message="Campo: DataAlteracao não pode ser nulo")
 	private LocalDateTime dataAlteracao;
 	
+	@NotNull(message="status do cliente não pode ser nulo")
 	private Status status;
 	
+	@NotNull(message="nome não pode ser nulo")
 	private String nome;
+	@NotNull(message="cpf não pode ser nulo")
 	private String cpf;
+	@NotNull(message="e-mail não pode ser nulo")
 	private String email;
+	@NotNull(message="telefone não pode ser nulo")
 	private String telefone;
+	@NotNull(message="celular não pode ser nulo")
 	private String celular;
+	@NotNull(message="nascimento não pode ser nulo")
 	private String nascimento;
-	
+	@NotNull(message="logradouro não pode ser nulo")
 	private String logradouro;
+	@NotNull(message="bairro não pode ser nulo")
 	private String bairro;
+	@NotNull(message="cidade não pode ser nulo")
 	private String cidade;
+	@NotNull(message="estado não pode ser nulo")
 	private String estado;
+	@NotNull(message="cep não pode ser nulo")
 	private String cep;
+	@NotNull(message="complemento não pode ser nulo")
 	private String complemento;
 	
 	public LocalDate getDataCadastro() {

--- a/src/main/java/net/atos/cliente/repository/ClienteRepository.java
+++ b/src/main/java/net/atos/cliente/repository/ClienteRepository.java
@@ -1,0 +1,11 @@
+package net.atos.cliente.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import net.atos.cliente.repository.entity.ClienteEntity;
+
+@Repository
+public interface ClienteRepository extends CrudRepository<ClienteEntity, Long>{
+	
+}

--- a/src/main/java/net/atos/cliente/repository/entity/ClienteEntity.java
+++ b/src/main/java/net/atos/cliente/repository/entity/ClienteEntity.java
@@ -1,45 +1,81 @@
-package net.atos.cliente.domain;
+package net.atos.cliente.repository.entity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
-public class Cliente {
+import net.atos.cliente.domain.Status;
+
+@Entity
+@Table(name = "TB_CLIENTE")
+public class ClienteEntity {
 	
+	@Id
+	@Column(name = "ID_CADASTRO")
 	private Long id;
 	
+	@Column(name = "DT_CADASTRO")
 	@NotNull(message="Campo: cadastroData não pode ser nulo")
 	private LocalDate dataCadastro;
 	
+	@Column(name = "DT_ALTERACAO")
 	@NotNull(message="Campo: DataAlteracao não pode ser nulo")
 	private LocalDateTime dataAlteracao;
 	
+	@Column(name = "STATUS")
 	@NotNull(message="status do cliente não pode ser nulo")
 	private Status status;
 	
+	@Column(name = "NOME")
 	@NotNull(message="nome não pode ser nulo")
 	private String nome;
+	
+	@Column(name = "CPF")
 	@NotNull(message="cpf não pode ser nulo")
 	private String cpf;
+	
+	@Column(name = "EMAIL")
 	@NotNull(message="e-mail não pode ser nulo")
 	private String email;
+	
+	@Column(name = "TELEFONE")
 	@NotNull(message="telefone não pode ser nulo")
 	private String telefone;
+	
+	@Column(name = "CELULAR")
 	@NotNull(message="celular não pode ser nulo")
 	private String celular;
+	
+	@Column(name = "NASCIMENTO")
 	@NotNull(message="nascimento não pode ser nulo")
 	private String nascimento;
+	
+	@Column(name = "LOGRADOURO")
 	@NotNull(message="logradouro não pode ser nulo")
 	private String logradouro;
+	
+	@Column(name = "BAIRRO")
 	@NotNull(message="bairro não pode ser nulo")
 	private String bairro;
+	
+	@Column(name = "CIDADE")
 	@NotNull(message="cidade não pode ser nulo")
 	private String cidade;
+	
+	@Column(name = "ESTADO")
 	@NotNull(message="estado não pode ser nulo")
 	private String estado;
+	
+	@Column(name = "CEP")
 	@NotNull(message="cep não pode ser nulo")
 	private String cep;
+	
+	@Column(name = "COMPLEMENTO")
 	@NotNull(message="complemento não pode ser nulo")
 	private String complemento;
 	

--- a/src/main/java/net/atos/cliente/service/CadastrarCliente.java
+++ b/src/main/java/net/atos/cliente/service/CadastrarCliente.java
@@ -12,17 +12,22 @@ import javax.ws.rs.BadRequestException;
 import org.springframework.stereotype.Service;
 
 import net.atos.cliente.domain.Cliente;
+import net.atos.cliente.repository.ClienteRepository;
+import net.atos.cliente.repository.entity.ClienteEntity;
 
 @Service
 public class CadastrarCliente {
 	
 	private Validator validator;
 	
-	public CadastrarCliente(Validator v) {
+	private ClienteRepository clienteRepository;
+	
+	public CadastrarCliente(Validator v, ClienteRepository repository) {
 		this.validator = v;
+		this.clienteRepository = repository;
 	}
 
-	public void persistir(@NotNull(message = "Cadastro não pode ser null") Cliente cliente) {
+	public Cliente persistir(@NotNull(message = "Cadastro não pode ser null") Cliente cliente) {
 		
 		Set<ConstraintViolation<Cliente>>
 			validate = this.validator.validate(cliente);
@@ -34,6 +39,30 @@ public class CadastrarCliente {
 		if(!cliente.getDataCadastro().isEqual(LocalDate.now())) {
 			throw new BadRequestException("A data do cadastro deve ser atual");
 		}
-	}
+		
+		ClienteEntity clienteEntity = new ClienteEntity();
+		clienteEntity.setDataCadastro(cliente.getDataCadastro());
+		clienteEntity.setDataAlteracao(cliente.getDataAlteracao());
+		clienteEntity.setStatus(cliente.getStatus());
+		clienteEntity.setNome(cliente.getNome());
+		clienteEntity.setCpf(cliente.getCpf());
+		clienteEntity.setEmail(cliente.getEmail());
+		clienteEntity.setTelefone(cliente.getTelefone());
+		clienteEntity.setCelular(cliente.getCelular());
+		clienteEntity.setNascimento(cliente.getNascimento());
+		clienteEntity.setLogradouro(cliente.getLogradouro());
+		clienteEntity.setBairro(cliente.getBairro());
+		clienteEntity.setCidade(cliente.getCidade());
+		clienteEntity.setEstado(cliente.getEstado());
+		clienteEntity.setCep(cliente.getCep());
+		clienteEntity.setComplemento(cliente.getComplemento());
+		
+		clienteRepository.save(clienteEntity);
+		
+		cliente.setId(clienteEntity.getId());
+		
+		return cliente;
 	
+	}
 }
+

--- a/src/main/java/net/atos/cliente/service/CadastrarCliente.java
+++ b/src/main/java/net/atos/cliente/service/CadastrarCliente.java
@@ -1,7 +1,12 @@
 package net.atos.cliente.service;
 
-import java.util.Optional;
+import java.time.LocalDate;
+import java.util.Set;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 
 import org.springframework.stereotype.Service;
@@ -10,26 +15,25 @@ import net.atos.cliente.domain.Cliente;
 
 @Service
 public class CadastrarCliente {
-	public void persistir(Cliente cliente) {
-		
-		Optional.ofNullable(cliente.getDataCadastro())
-				.orElseThrow(() -> new BadRequestException("Campo: cadastroData não pode ser nulo"));
-		Optional.ofNullable(cliente.getDataAlteracao())
-				.orElseThrow(() -> new BadRequestException("Campo: DataAlteracao não pode ser nulo"));
-		Optional.ofNullable(cliente.getStatus())
-				.orElseThrow(() -> new BadRequestException("status do cliente não pode ser nulo"));
-		Optional.ofNullable(cliente.getNome())
-				.orElseThrow(() -> new BadRequestException("nome não pode ser nulo"));
-		Optional.ofNullable(cliente.getCpf())
-				.orElseThrow(() -> new BadRequestException("cpf não pode ser nulo"));
-		Optional.ofNullable(cliente.getEmail())
-				.orElseThrow(() -> new BadRequestException("email não pode ser nulo"));
-		Optional.ofNullable(cliente.getTelefone())
-				.orElseThrow(() -> new BadRequestException("telefone não pode ser nulo"));
-		Optional.ofNullable(cliente.getCelular())
-				.orElseThrow(() -> new BadRequestException("celular não pode ser nulo"));
-		Optional.ofNullable(cliente.getNascimento())
-				.orElseThrow(() -> new BadRequestException("nascimento não pode ser nulo"));
-
+	
+	private Validator validator;
+	
+	public CadastrarCliente(Validator v) {
+		this.validator = v;
 	}
+
+	public void persistir(@NotNull(message = "Cadastro não pode ser null") Cliente cliente) {
+		
+		Set<ConstraintViolation<Cliente>>
+			validate = this.validator.validate(cliente);
+		
+		if(!validate.isEmpty()) {
+			throw new ConstraintViolationException("Operação inválida", validate);
+		}
+		
+		if(!cliente.getDataCadastro().isEqual(LocalDate.now())) {
+			throw new BadRequestException("A data do cadastro deve ser atual");
+		}
+	}
+	
 }

--- a/src/test/java/net/atos/cliente/service/CadastrarClienteTest.java
+++ b/src/test/java/net/atos/cliente/service/CadastrarClienteTest.java
@@ -1,170 +1,114 @@
 package net.atos.cliente.service;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import javax.ws.rs.BadRequestException;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import net.atos.cliente.domain.Status;
 import net.atos.cliente.domain.Cliente;
+import net.atos.cliente.domain.Status;
 
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
 class CadastrarClienteTest {
 
 	private CadastrarCliente cadastrarCliente;
 	
+	private Validator validator;
+	
+	@BeforeAll
+	public void iniciarTesteGeral() {
+		ValidatorFactory validatorFactor =
+				Validation.buildDefaultValidatorFactory();
+		
+		this.validator = validatorFactor.getValidator();
+	}
+	
 	@BeforeEach
 	public void iniciarTeste() {
-		cadastrarCliente = new CadastrarCliente();
+		cadastrarCliente = new CadastrarCliente(validator);
 	}
 	
 	@Test
-	@DisplayName("Teste do campo: data de cadastro")
-	public void test_dataCadastro_null_lancarExcessao() {
+	@DisplayName("Testa o Cadastro quando for nulo")
+	public void test_cadastro_null_lancarExcessao() {
 		
 		assertNotNull(cadastrarCliente);
 		
-		Cliente cliente = new Cliente();
+		Cliente cliente = null;
 		
-		var assertThrows = assertThrows(BadRequestException.class, () -> cadastrarCliente.persistir(cliente));
-		
-		assertEquals("Campo: cadastroData não pode ser nulo", assertThrows.getMessage());
-	}
-	
-	@Test
-	@DisplayName("Teste do campo: data de alteração")
-	public void test_dataAlteracao_null_lancarExcessao() {
-		
-		assertNotNull(cadastrarCliente);
-		
-		Cliente cliente = new Cliente();
-		cliente.setDataCadastro(LocalDate.now());
-		
-		var assertThrows = assertThrows(BadRequestException.class, () -> cadastrarCliente.persistir(cliente));
-		
-		assertEquals("Campo: DataAlteracao não pode ser nulo", assertThrows.getMessage());	
-	}
-	
-	@Test
-	@DisplayName("Teste do status do cliente")
-	public void test_status_null_lancarExcessao() {
-		
-		assertNotNull(cadastrarCliente);
-		
-		Cliente cliente = new Cliente();
-		cliente.setDataCadastro(LocalDate.now());
-		cliente.setDataAlteracao(LocalDateTime.now());
-		
-		var assertThrows = assertThrows(BadRequestException.class, () -> cadastrarCliente.persistir(cliente));
-		
-		assertEquals("status do cliente não pode ser nulo", assertThrows.getMessage());
-	}
-	
-	@Test
-	@DisplayName("Teste do campo: nome")
-	public void nome_null() {
-		
-		assertNotNull(cadastrarCliente);
-		
-		Cliente cliente = new Cliente();
-		cliente.setDataCadastro(LocalDate.now());
-		cliente.setDataAlteracao(LocalDateTime.now());
-		cliente.setStatus(Status.INATIVO);
-		
-		var assertThrows = assertThrows(BadRequestException.class, () -> cadastrarCliente.persistir(cliente));
-		
-		assertEquals("nome não pode ser nulo", assertThrows.getMessage());
-	}
-	
-	@Test
-	@DisplayName("Teste do campo: cpf")
-	public void cpf_null() {
-		
-		assertNotNull(cadastrarCliente);
-		
-		Cliente cliente = new Cliente();
-		cliente.setDataCadastro(LocalDate.now());
-		cliente.setDataAlteracao(LocalDateTime.now());
-		cliente.setStatus(Status.INATIVO);
-		cliente.setNome("Nome do cliente");
-		
-		var assertThrows = assertThrows(BadRequestException.class, () -> cadastrarCliente.persistir(cliente));
-		
-		assertEquals("cpf não pode ser nulo", assertThrows.getMessage());
-	}
+		var assertThrows = assertThrows(IllegalArgumentException.class, () ->
+			cadastrarCliente.persistir(cliente));
 
-	@Test
-	@DisplayName("Teste do campo: email")
-	public void email_null() {
-		
-		assertNotNull(cadastrarCliente);
-		
-		Cliente cliente = new Cliente();
-		cliente.setDataCadastro(LocalDate.now());
-		cliente.setDataAlteracao(LocalDateTime.now());
-		cliente.setStatus(Status.INATIVO);
-		cliente.setNome("Nome do cliente");
-		cliente.setCpf("000.000.000-99");
-		
-		var assertThrows = assertThrows(BadRequestException.class, () -> cadastrarCliente.persistir(cliente));
-		
-		assertEquals("email não pode ser nulo", assertThrows.getMessage());
+		assertNotNull(assertThrows);
 	}
 	
 	@Test
-	@DisplayName("Teste do campo: telefone")
-	public void telefone_null() {
+	@DisplayName("Testa os campos obrigatórios")
+	public void test_camposCadastro_null_lancarExcessao() {
 		
 		assertNotNull(cadastrarCliente);
 		
 		Cliente cliente = new Cliente();
-		cliente.setDataCadastro(LocalDate.now());
-		cliente.setDataAlteracao(LocalDateTime.now());
-		cliente.setStatus(Status.INATIVO);
-		cliente.setNome("Nome do cliente");
-		cliente.setCpf("000.000.000-99");
-		cliente.setEmail("teste@email.com.br");
 		
-		var assertThrows = assertThrows(BadRequestException.class, () -> cadastrarCliente.persistir(cliente));
+		var assertThrows = assertThrows(ConstraintViolationException.class, () ->
+			cadastrarCliente.persistir(cliente));
 		
-		assertEquals("telefone não pode ser nulo", assertThrows.getMessage());
+		assertEquals(15, assertThrows.getConstraintViolations().size());
+		List<String> mensagens = assertThrows.getConstraintViolations()
+			.stream()
+			.map(ConstraintViolation::getMessage)
+			.collect(Collectors.toList());
+		
+		assertThat(mensagens, hasItems(
+				"Campo: cadastroData não pode ser nulo",
+				"Campo: DataAlteracao não pode ser nulo",
+				"status do cliente não pode ser nulo",
+				"nome não pode ser nulo",
+				"cpf não pode ser nulo",
+				"e-mail não pode ser nulo",
+				"telefone não pode ser nulo",
+				"celular não pode ser nulo",
+				"nascimento não pode ser nulo",
+				"logradouro não pode ser nulo",
+				"bairro não pode ser nulo",
+				"cidade não pode ser nulo",
+				"estado não pode ser nulo",
+				"cep não pode ser nulo",
+				"complemento não pode ser nulo"
+				));
 	}
 	
 	@Test
-	@DisplayName("Teste do campo: celular")
-	public void celular_null() {
+	@DisplayName("Campo data de cadastro atual")
+	public void test_data_diferente_lancaExcecao() {
 		
 		assertNotNull(cadastrarCliente);
 		
 		Cliente cliente = new Cliente();
-		cliente.setDataCadastro(LocalDate.now());
-		cliente.setDataAlteracao(LocalDateTime.now());
-		cliente.setStatus(Status.INATIVO);
-		cliente.setNome("Nome do cliente");
-		cliente.setCpf("000.000.000-99");
-		cliente.setEmail("teste@email.com.br");
-		cliente.setTelefone("(99) 9999-9999");
-		
-		var assertThrows = assertThrows(BadRequestException.class, () -> cadastrarCliente.persistir(cliente));
-		
-		assertEquals("celular não pode ser nulo", assertThrows.getMessage());
-	}
-	
-	@Test
-	@DisplayName("Teste do campo: nascimento")
-	public void nascimento_null() {
-		
-		assertNotNull(cadastrarCliente);
-		
-		Cliente cliente = new Cliente();
-		cliente.setDataCadastro(LocalDate.now());
+		cliente.setDataCadastro(LocalDate.now().minusDays(1l));
 		cliente.setDataAlteracao(LocalDateTime.now());
 		cliente.setStatus(Status.INATIVO);
 		cliente.setNome("Nome do cliente");
@@ -172,10 +116,17 @@ class CadastrarClienteTest {
 		cliente.setEmail("teste@email.com.br");
 		cliente.setTelefone("(99) 9999-9999");
 		cliente.setCelular("(99) 9 9999-9999");
+		cliente.setNascimento("01/01/1901");
+		cliente.setLogradouro("Rua do Brasil, 1500");
+		cliente.setBairro("Vila Brasil");
+		cliente.setCidade("Java");
+		cliente.setEstado("Brasil");
+		cliente.setCep("01234-567");
+		cliente.setComplemento("Clube dos Javeiros");
 		
 		var assertThrows = assertThrows(BadRequestException.class, () -> cadastrarCliente.persistir(cliente));
 		
-		assertEquals("nascimento não pode ser nulo", assertThrows.getMessage());
+		assertEquals("A data do cadastro deve ser atual", assertThrows.getMessage());
 	}
 
 }

--- a/src/test/java/net/atos/cliente/service/CadastrarClienteTest.java
+++ b/src/test/java/net/atos/cliente/service/CadastrarClienteTest.java
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -25,10 +28,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import net.atos.cliente.domain.Cliente;
 import net.atos.cliente.domain.Status;
+import net.atos.cliente.repository.ClienteRepository;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
@@ -37,6 +42,7 @@ class CadastrarClienteTest {
 	private CadastrarCliente cadastrarCliente;
 	
 	private Validator validator;
+	private ClienteRepository clienteRepository;
 	
 	@BeforeAll
 	public void iniciarTesteGeral() {
@@ -48,7 +54,10 @@ class CadastrarClienteTest {
 	
 	@BeforeEach
 	public void iniciarTeste() {
-		cadastrarCliente = new CadastrarCliente(validator);
+		
+		this.clienteRepository = Mockito.mock(ClienteRepository.class);
+		
+		cadastrarCliente = new CadastrarCliente(validator, clienteRepository);
 	}
 	
 	@Test
@@ -127,6 +136,34 @@ class CadastrarClienteTest {
 		var assertThrows = assertThrows(BadRequestException.class, () -> cadastrarCliente.persistir(cliente));
 		
 		assertEquals("A data do cadastro deve ser atual", assertThrows.getMessage());
+	}
+	
+	@Test
+	@DisplayName("Teste de persistência do cadastro")
+	public void test_dados_preenchidos_cadastroCriado() {
+		
+		assertNotNull(cadastrarCliente);
+		
+		Cliente cliente = new Cliente();
+		cliente.setDataCadastro(LocalDate.now());
+		cliente.setDataAlteracao(LocalDateTime.now());
+		cliente.setStatus(Status.INATIVO);
+		cliente.setNome("Nome do cliente");
+		cliente.setCpf("000.000.000-99");
+		cliente.setEmail("teste@email.com.br");
+		cliente.setTelefone("(99) 9999-9999");
+		cliente.setCelular("(99) 9 9999-9999");
+		cliente.setNascimento("01/01/1901");
+		cliente.setLogradouro("Rua do Brasil, 1500");
+		cliente.setBairro("Vila Brasil");
+		cliente.setCidade("Java");
+		cliente.setEstado("Brasil");
+		cliente.setCep("01234-567");
+		cliente.setComplemento("Clube dos Javeiros");
+		
+		cadastrarCliente.persistir(cliente);
+		
+		then(clienteRepository).should(times(1)).save(any());
 	}
 
 }


### PR DESCRIPTION
Refatorando os testes de cadastros.

Alterações:
- pom.xml: dependências;
- classes: Service/Domain;
- classesTest: CadastrarClienteTest;

Teste de persistência do cadastro:
-MockitoExtension;
-persistence.Table.

- classe: ClienteEntity;
- interface: ClienteRepository;
